### PR TITLE
Ignore `*-lock.json` for PR size validation

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -51,6 +51,7 @@ mergeable:
       - do: size
         ignore: 
           - '*.lock'
+          - '*-lock.json'
         lines:
           max:
             count: 500


### PR DESCRIPTION
This is to ignore `*-lock.json` for PR size validation.