### PR TITLE
Switch to forked version for sync repo settings

### DIFF
--- a/.github/workflows/sync-settings-in-respositories.yml
+++ b/.github/workflows/sync-settings-in-respositories.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repo Setup
-        uses: kbrashears5/github-action-repo-settings-sync@master
+        uses: tenshiAMD/github-action-repo-settings-sync@master
         with:
           DELETE_HEAD: 'true'
           TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This is to switch using forked version for sync repo settings.